### PR TITLE
Add __name__== "__main__" condition on the main cli file

### DIFF
--- a/sigma/cli/main.py
+++ b/sigma/cli/main.py
@@ -13,3 +13,7 @@ def main():
     cli.add_command(convert)
     cli.add_command(check)
     cli()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows to run sigma-cli directly with python without using the `sigma` command, thus facilitates development with breakpoints.

Example command: `python -m sigma.cli.main convert --help`