### PR TITLE
Fix: Error in Wrong Pipeline Checker

### DIFF
--- a/sigma/cli/convert.py
+++ b/sigma/cli/convert.py
@@ -111,7 +111,7 @@ def convert(target, pipeline, without_pipeline, pipeline_check, format, skip_uns
         wrong_pipelines = [
             p
             for p in pipeline
-            if not (pipelines[p].backends == () or target in pipelines[p].backends)
+            if pipelines.get(p, False) and not (pipelines[p].backends == () or target in pipelines[p].backends)
         ]
         if len(wrong_pipelines) > 0:
             raise click.UsageError(textwrap.dedent(f"""

--- a/tests/files/custom_pipeline.yml
+++ b/tests/files/custom_pipeline.yml
@@ -1,0 +1,7 @@
+name: Custom Pipeline
+priority: 100
+transformations:
+  - id: field_mapping
+    type: field_name_mapping
+    mapping:
+      ParentImage: some_other_string

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -78,3 +78,9 @@ def test_convert_wrong_pipeline_ignore():
     cli = CliRunner()
     result = cli.invoke(convert, ["-t", "splunk", "-p", "ecs_windows", "--disable-pipeline-check", "tests/files/valid"])
     assert "process.executable" in result.stdout
+
+def test_yml_pipeline_doesnt_trigger_wrong_pipeline():
+    cli = CliRunner()
+    result = cli.invoke(convert, ["-t", "splunk", "-p", "splunk_windows", "-p", "tests/files/custom_pipeline.yml", "tests/files/valid"])
+    print(result.stdout)
+    assert "some_other_string" in result.stdout


### PR DESCRIPTION
Whist adding a test for a `yml` file pipeline, found a bug in the wrong pipelines checker that incorrectly assumed that file pipelines (e.g. `./custom_pipeline.yml`) should be in list pipelines[p]. The wrong pipeline checker now first checks to see if it's in the predefined list.