### PR TITLE
Move progress bar to stderr

### DIFF
--- a/sigma/cli/check.py
+++ b/sigma/cli/check.py
@@ -3,6 +3,7 @@ from textwrap import fill
 import click
 from collections import Counter
 from prettytable import PrettyTable
+from sys import stderr
 
 from sigma.exceptions import SigmaConditionError, SigmaError
 from sigma.cli.rules import load_rules
@@ -78,7 +79,7 @@ def check(input, validation_config, file_pattern, fail_on_error, fail_on_issues)
         rule_error_count = sum(rule_errors.values())
         #rule_error_count = rule_errors.total()
 
-        with click.progressbar(check_rules, label="Checking Sigma rules") as rules:
+        with click.progressbar(check_rules, label="Checking Sigma rules", file=stderr) as rules:
             issues = rule_validator.validate_rules(rules)
 
         issue_count = len(issues)

--- a/sigma/cli/rules.py
+++ b/sigma/cli/rules.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from sys import stderr
 import click
 from sigma.collection import SigmaCollection
 
@@ -10,7 +11,7 @@ def load_rules(input, file_pattern):
             input,
             recursion_pattern="**/" + file_pattern,
         )
-        with click.progressbar(list(rule_paths), label="Parsing Sigma rules") as progress_rule_paths:
+        with click.progressbar(list(rule_paths), label="Parsing Sigma rules", file=stderr) as progress_rule_paths:
             rule_collection = SigmaCollection.load_ruleset(
                 progress_rule_paths,
                 collect_errors=True,


### PR DESCRIPTION
Hello there, this PR moves the progress bar from stdout to stderr.
This allows the output from `sigma convert` to be piped to other commands, such as `jq` for json-formatted queries.