### PR TITLE
Fix check exclude option

### DIFF
--- a/sigma/cli/check.py
+++ b/sigma/cli/check.py
@@ -68,13 +68,25 @@ def check(
     if (
         validation_config is None
     ):  # no validation config provided, use basic config with all validators
-        if exclude:
-            click.echo(f"Ignoring these validators: {exclude}")
         exclude_lower = [excluded.lower() for excluded in exclude]
+        exclude_invalid = [
+            excluded for excluded in exclude_lower if excluded not in validators.keys()
+        ]
+        exclude_valid = [
+            excluded for excluded in exclude_lower if excluded not in exclude_invalid
+        ]
+
+        if len(exclude_invalid) > 0:
+            click.echo(
+                f"Invalid validators name : {exclude_invalid} use 'sigma list validator'"
+            )
+        if len(exclude_valid) > 0:
+            click.echo(f"Ignoring these validators : {exclude_valid}'")
+
         validators_filtered = [
             validator
             for name, validator in validators.items()
-            if name.lower() not in exclude_lower
+            if name.lower() not in exclude_valid
         ]
         rule_validator = SigmaValidator(validators_filtered)
     else:

--- a/sigma/cli/check.py
+++ b/sigma/cli/check.py
@@ -49,7 +49,7 @@ severity_color = {"low": "green", "medium": "yellow", "high": "red"}
 )
 @click.option(
     "--exclude",
-    "-e",
+    "-x",
     default=[],
     show_default=True,
     multiple=True,
@@ -73,8 +73,8 @@ def check(
         exclude_lower = [excluded.lower() for excluded in exclude]
         validators_filtered = [
             validator
-            for validator in validators.values()
-            if validator.__name__.lower() not in exclude_lower
+            for name, validator in validators.items()
+            if name.lower() not in exclude_lower
         ]
         rule_validator = SigmaValidator(validators_filtered)
     else:

--- a/sigma/cli/check.py
+++ b/sigma/cli/check.py
@@ -78,7 +78,7 @@ def check(
 
         if len(exclude_invalid) > 0:
             click.echo(
-                f"Invalid validators name : {exclude_invalid} use 'sigma list validator'"
+                f"Invalid validators name : {exclude_invalid} use 'sigma list validators'"
             )
         if len(exclude_valid) > 0:
             click.echo(f"Ignoring these validators : {exclude_valid}'")

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -68,14 +68,22 @@ def test_check_fail_on_issues():
 
 def test_check_exclude():
     cli = CliRunner()
-    result = cli.invoke(check, ["--fail-on-issues",
-                                "--exclude",
-                                "InvalidRelatedTypeValidator",
-                                "--exclude",
-                                "StatusExistenceValidator",
-                                "--exclude",
-                                "DateExistenceValidator",
-                                "tests/files/issues/sigma_rule_with_bad_references.yml"])
+    result = cli.invoke(
+        check,
+        [
+            "--fail-on-issues",
+            "--exclude",
+            "Invalid_Related_Type",
+            "--exclude",
+            "status_existence",
+            "-x",
+            "date_existence",
+            "--exclude",
+            "MyValidator",
+            "tests/files/issues/sigma_rule_with_bad_references.yml",
+        ],
+    )
     assert result.exit_code == 0
+    assert "Invalid validators name" in result.stdout
+    assert "myvalidator" in result.stdout
     assert "Ignoring these validators" in result.stdout
-    assert "InvalidRelatedTypeValidator" in result.stdout


### PR DESCRIPTION
Fix : 
- duplicate `-e` option
- the exclude option 

![image](https://github.com/SigmaHQ/sigma-cli/assets/62423083/b408e544-ba58-46e1-bb21-73a00c18cbcf)

Now check if the excluded validator name exist 
```bash
PS D:\rootme\sigma-cli> poetry run sigma check D:\rootme\sigma\rules* -x Escaped_Wildcard -x fr
Invalid validators name : ['fr'] use 'sigma list validators'
Ignoring these validators : ['escaped_wildcard']'
Parsing Sigma rules  [########----------------------------]   24%  00:00:06
```
