### PR TITLE
Add the short option for help command: `-h`

### DIFF
--- a/sigma/cli/main.py
+++ b/sigma/cli/main.py
@@ -37,7 +37,12 @@ from .analyze import analyze_group
 from .pysigma import check_pysigma_command
 
 
-@click.group()
+CONTEXT_SETTINGS={
+    "help_option_names": ['-h', '--help']
+}
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     pass
 


### PR DESCRIPTION
It's much easier for people use `-h` command-line switch instead of longer `--help` to retrieve the help about CLI or a specific command.  This PR extends the current behavior by allowing the short option as well in addition to longer one.