### PR TITLE
Fixed Multiple Backend Error Reporting

### DIFF
--- a/sigma/cli/convert.py
+++ b/sigma/cli/convert.py
@@ -346,4 +346,4 @@ def convert(
     if len(backend.errors) > 0:
         click.echo("\nIgnored errors:", err=True)
         for rule, error in backend.errors:
-            raise click.ClickException(f"{str(rule.source)}: {str(error)}")
+            click.echo(f"{str(rule.source)}: {str(error)}", err=True)


### PR DESCRIPTION
Suggested fix for #71 
Switched out click.ClickException to prevent early exit before printing all backend errors.