### PR TITLE
Include Homebrew installation for sigma-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ on macOS use
 ```
 python3 -m pip install sigma-cli
 ```
+```
+brew install sigma-cli
+```
 
 Another way is to run this from source in a virtual environment managed by [Poetry](https://python-poetry.org/docs/basic-usage/):
 


### PR DESCRIPTION
Added an additional option for installing on macOS systems.
<img width="1828" height="972" alt="image" src="https://github.com/user-attachments/assets/a0b82e93-83f7-4088-9ab2-2375900678a7" />
